### PR TITLE
Cleaned up loading result text a bit

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -73,7 +73,8 @@
     result = UNKOWN_RESULT;
   }
 
-  function doCompute() {
+  function doCompute(e) {
+    e.preventDefault() //prevents jumpscrolling to the top on button press.
     if (isWorking) {
       worker.terminate();
       isWorking = false;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -290,11 +290,21 @@
   <div>
     {#if isWorking}
       <Bar percentage={(result.covered / gameToPlay) * 100} />
-      <small
-        >Looking into the future #{result.covered}
-        <br />You are winning {result.win}
-        ({result.winRate.toFixed(1)}%) games so far</small
-      >
+        <!-- essentially only changed numbers to font-mono and restructured html. 
+             added margin top to the first line and font-bold to result.
+            now the numbers won't jitter as they are changing, being easier on the eyes, generally more clean look.
+            -->
+        <small class="flex justify-center items-center flex-col gap-5" >
+            <div class="mt-5">
+                <span>Looking into the future</span>
+                <span class="font-mono">#{result.covered}</span>
+            </div>
+            <div class="my-auto flex"> 
+                <span>You are winning &nbsp</span>
+                <span class="font-mono font-bold">{result.win} ({result.winRate.toFixed(1)}%)</span>
+                <span>&nbsp;games so far</span>
+            </div>
+        </small>
     {:else if result.total > 0}
       <Result {result} />
     {:else}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -299,9 +299,16 @@
                 <span>Looking into the future</span>
                 <span class="font-mono">#{result.covered}</span>
             </div>
-            <div class="my-auto flex"> 
+            <div class="my-auto flex items-baseline"> 
                 <span>You are winning &nbsp</span>
-                <span class="font-mono font-bold">{result.win} ({result.winRate.toFixed(1)}%)</span>
+                <div class="font-mono font-bold w-10 flex flex-col justify-center items-center">
+                    <div class="">
+                        {result.win} 
+                    </div>
+                    
+                   ({result.winRate.toFixed(1)}%)
+                
+                </div>
                 <span>&nbsp;games so far</span>
             </div>
         </small>


### PR DESCRIPTION
Explained in the comment i made on your reddit post and the code comment. Cleaned the styling up so the text doesn't jitter when the number changes. 

I only really changed the numbers to tailwindcss font-mono, and then restructured the html so the spans works, centering etc (looking the same as before, except the first line have some margin at the top.) 

also had the audacity to change the results to bold, since i think it looks nice. 

as an alternative  (and even more jitter free) look, check out the third commit. otherwise if you prefer the old look but jitter free, just ignore the third one. 

last update, 4th commit prevents screen from scrolling to the top when clicking on a button. e.preventDefault is standard practice for 80% of buttons so here ya go.

let me know what you think!